### PR TITLE
Decouple Browser

### DIFF
--- a/src/js/luge.js
+++ b/src/js/luge.js
@@ -9,6 +9,7 @@ import ViewportObserver from 'Core/ViewportObserver'
 import MouseObserver from 'Core/MouseObserver'
 import ScrollObserver from 'Core/ScrollObserver'
 import Ticker from 'Core/Ticker'
+import Browser from 'Core/Browser'
 
 import Cursor from 'Plugins/Cursor'
 import Intersection from 'Plugins/Intersection'
@@ -21,8 +22,20 @@ import ScrollAnimation from 'Plugins/ScrollAnimation'
 import SmoothScroll from 'Plugins/SmoothScroll'
 import Transition from 'Plugins/Transition'
 
+const browser = Browser.bowser
+
+Luge.setSettings({
+  cursor: {
+    disabled: browser.some(['tablet', 'mobile'])
+  },
+  smooth: {
+    disabled: browser.some(['tablet', 'mobile']) || browser.satisfies({ safari: '<=12' })
+  }
+})
+
 // Public methods
 const luge = {
+  browser,
   cursor: {},
   emitter: {
     emit: Emitter.emit.bind(Emitter),

--- a/src/js/luge/core/Browser.js
+++ b/src/js/luge/core/Browser.js
@@ -1,0 +1,28 @@
+import Bowser from 'bowser'
+
+class Browser {
+  /**
+   * Constructor
+   */
+  constructor () {
+    // Browser detect
+    const browser = Bowser.getParser(window.navigator.userAgent)
+
+    // Platform type class
+    document.documentElement.classList.add('is-' + browser.getPlatformType())
+
+    if (browser.is('mobile') || browser.is('tablet')) {
+      document.documentElement.classList.add('is-handheld')
+    }
+
+    // Browser class
+    if (browser.is('Safari')) {
+      document.documentElement.classList.add('is-safari')
+      document.documentElement.classList.add('is-safari-' + browser.getBrowserVersion())
+    }
+
+    this.bowser = browser
+  }
+}
+
+export default new Browser()

--- a/src/js/luge/core/Core.js
+++ b/src/js/luge/core/Core.js
@@ -1,4 +1,3 @@
-import Bowser from 'bowser'
 import LifeCycle from 'Core/LifeCycle'
 import Emitter from 'Core/Emitter'
 import Helpers from 'Core/Helpers'
@@ -11,7 +10,6 @@ class Luge {
     // Options
     this.settings = {
       cursor: {
-        disabled: ['tablet', 'mobile'],
         inertia: 1,
         trailLength: 10
       },
@@ -39,7 +37,6 @@ class Luge {
         inertia: 0.1
       },
       smooth: {
-        disabled: ['tablet', 'mobile', { safari: '<=12' }],
         inertia: 0.1
       },
       ticker: {
@@ -76,22 +73,6 @@ class Luge {
     window.mouseX = -1
     window.mouseY = -1
     window.mouseLastScrollTop = 0
-
-    // Browser detect
-    window.browser = Bowser.getParser(window.navigator.userAgent)
-
-    // Platform type class
-    document.documentElement.classList.add('is-' + window.browser.getPlatformType())
-
-    if (window.browser.is('mobile') || window.browser.is('tablet')) {
-      document.documentElement.classList.add('is-handheld')
-    }
-
-    // Browser class
-    if (window.browser.is('Safari')) {
-      document.documentElement.classList.add('is-safari')
-      document.documentElement.classList.add('is-safari-' + window.browser.getBrowserVersion())
-    }
 
     LifeCycle.add('siteInit', this.siteInit.bind(this), 999)
 

--- a/src/js/luge/core/Plugin.js
+++ b/src/js/luge/core/Plugin.js
@@ -38,28 +38,7 @@ export default class Plugin {
    * Check if feature is disabled
    */
   disabled () {
-    let disabled = false
-    if (typeof Luge.settings[this.pluginSlug] !== 'undefined' && typeof Luge.settings[this.pluginSlug].disabled !== 'undefined') {
-      disabled = Luge.settings[this.pluginSlug].disabled
-    }
-
-    if (Helpers.isString(disabled)) {
-      disabled = window.browser.is(disabled, true)
-    } else if (Helpers.isArray(disabled)) {
-      disabled = disabled.some(element => {
-        if (Helpers.isString(element)) {
-          return window.browser.is(element, true)
-        } else if (Helpers.isObject(element)) {
-          return window.browser.satisfies(element)
-        }
-
-        return false
-      })
-    } else if (Helpers.isObject(disabled)) {
-      disabled = window.browser.satisfies(disabled)
-    }
-
-    return disabled
+    return !!(Luge.settings[this.pluginSlug] || {}).disabled
   }
 
   /**

--- a/src/js/luge/plugins/Parallax.js
+++ b/src/js/luge/plugins/Parallax.js
@@ -112,11 +112,13 @@ class Parallax extends Plugin {
       const disable = attributes.disable
       let enable = true
 
-      if (disable) {
-        if ((disable === 'desktop' && window.browser.is('desktop')) ||
-            (disable === 'handheld' && !window.browser.is('desktop')) ||
-            (disable === 'mobile' && window.browser.is('mobile')) ||
-            (disable === 'tablet' && window.browser.is('tablet'))) {
+      const is = (window.luge.browser || {}).is
+
+      if (disable && is) {
+        if ((disable === 'desktop' && is('desktop')) ||
+            (disable === 'handheld' && !is('desktop')) ||
+            (disable === 'mobile' && is('mobile')) ||
+            (disable === 'tablet' && is('tablet'))) {
           enable = false
         }
       }


### PR DESCRIPTION
this changes make it easier to use Luge as ESM and exclude `Bowser` from bundle to save 25KB

Breaking changes:

* `window.browser` renamed to `window.luge.browser`.
* `disabled` setting no longer accept non-boolean.

Example of usage:

```
luge.settings({
  cursor: {
    disabled: window.luge.browser.some(['tablet', 'mobile'])
  },
  smooth: {
    disabled: window.luge.browser.some(['tablet', 'mobile']) || browser.satisfies({ safari: '<=12' })
  }
})

console.log(luge.browser.is('mobile'));
```